### PR TITLE
Use timex_datalink_client 0.12.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,21 +3,35 @@ PATH
   specs:
     timex_datalink_crt (0.1.0)
       ruby-sdl2 (~> 0.3.5)
-      timex_datalink_client (~> 0.8.0)
+      timex_datalink_client (~> 0.12.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activemodel (7.0.6)
+      activesupport (= 7.0.6)
+    activesupport (7.0.6)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    concurrent-ruby (1.2.2)
     crc (0.4.2)
     ffi (1.15.5)
+    i18n (1.14.1)
+      concurrent-ruby (~> 1.0)
     mdb (0.5.0)
+    minitest (5.18.1)
     ruby-sdl2 (0.3.5)
     rubyserial (0.6.0)
       ffi (~> 1.9, >= 1.9.3)
-    timex_datalink_client (0.8.0)
+    timex_datalink_client (0.12.1)
+      activemodel (~> 7.0.4)
       crc (~> 0.4.2)
       mdb (~> 0.5.0)
       rubyserial (~> 0.6.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
 
 PLATFORMS
   x86_64-linux

--- a/README.md
+++ b/README.md
@@ -16,14 +16,26 @@ This library consumes packets compiled with [timex\_datalink\_client](https://gi
 require "timex_datalink_client"
 require "timex_datalink_crt"
 
-time1 = Time.now
-time2 = time1.dup.utc
+time_local = Time.now
+time_utc = time_local.dup.utc
 
 models = [
   TimexDatalinkClient::Protocol3::Sync.new,
   TimexDatalinkClient::Protocol3::Start.new,
-  TimexDatalinkClient::Protocol3::Time.new(zone: 1, is_24h: false, date_format: 2, time: time1),
-  TimexDatalinkClient::Protocol3::Time.new(zone: 2, is_24h: true, date_format: 2, time: time2),
+
+  TimexDatalinkClient::Protocol3::Time.new(
+    zone: 1,
+    time: time_local,
+    is_24h: false,
+    date_format: "%y-%m-%d"
+  ),
+  TimexDatalinkClient::Protocol3::Time.new(
+    zone: 2,
+    time: time_utc,
+    is_24h: true,
+    date_format: "%y-%m-%d"
+  ),
+
   TimexDatalinkClient::Protocol3::End.new
 ]
 

--- a/timex_datalink_crt.gemspec
+++ b/timex_datalink_crt.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
   ]
 
   s.add_dependency "ruby-sdl2", "~> 0.3.5"
-  s.add_dependency "timex_datalink_client", "~> 0.8.0"
+  s.add_dependency "timex_datalink_client", "~> 0.12.1"
 end


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_crt/issues/7!

This PR updates this lib to use timex_datalink_client 0.12.1! :tada: 

Also includes some changes to the code example in README.md to reflect the date_format param change to `TimexDatalinkClient::Protocol3::Time.new` :ok_hand: 