### PR TITLE
Use ruby-sdl2 version 0.3.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GEM
       concurrent-ruby (~> 1.0)
     mdb (0.5.0)
     minitest (5.18.1)
-    ruby-sdl2 (0.3.5)
+    ruby-sdl2 (0.3.6)
     rubyserial (0.6.0)
       ffi (~> 1.9, >= 1.9.3)
     timex_datalink_client (0.12.1)


### PR DESCRIPTION
Closes https://github.com/synthead/timex_datalink_crt/issues/9.

Tiny :pinching_hand: PR to update ruby-sdl2 to version 0.3.6 :ok_hand: 