### PR TITLE
Upgrade timex_datalink_client gem to 0.12.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     timex_datalink_crt (0.1.0)
       ruby-sdl2 (~> 0.3.5)
-      timex_datalink_client (~> 0.12.1)
+      timex_datalink_client (~> 0.12.2)
 
 GEM
   remote: https://rubygems.org/
@@ -17,19 +17,17 @@ GEM
       tzinfo (~> 2.0)
     concurrent-ruby (1.2.2)
     crc (0.4.2)
-    ffi (1.15.5)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     mdb (0.5.0)
-    minitest (5.18.1)
+    minitest (5.19.0)
     ruby-sdl2 (0.3.6)
-    rubyserial (0.6.0)
-      ffi (~> 1.9, >= 1.9.3)
-    timex_datalink_client (0.12.1)
+    serialport (1.3.2)
+    timex_datalink_client (0.12.2)
       activemodel (~> 7.0.4)
       crc (~> 0.4.2)
       mdb (~> 0.5.0)
-      rubyserial (~> 0.6.0)
+      serialport (~> 1.3.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
 

--- a/timex_datalink_crt.gemspec
+++ b/timex_datalink_crt.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
   ]
 
   s.add_dependency "ruby-sdl2", "~> 0.3.5"
-  s.add_dependency "timex_datalink_client", "~> 0.12.1"
+  s.add_dependency "timex_datalink_client", "~> 0.12.2"
 end


### PR DESCRIPTION
Fixes https://github.com/synthead/timex_datalink_crt/issues/11!

Upgrades timex_datalink_client gem to 0.12.2 :+1: 